### PR TITLE
Add --scheme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ Examples:
   # Open service/kubernetes-dashboard in namespace/kube-system
   kubectl open-svc kubernetes-dashboard -n kube-system
 
+  # Use "https" scheme with --scheme option for connections between the apiserver
+  # and service/rook-ceph-mgr-dashboard in namespace/rook-ceph
+  kubectl open-svc rook-ceph-mgr-dashboard -n rook-ceph --scheme https
+
 Flags:
       --address string                   The IP address on which to serve on. (default "127.0.0.1")
       --alsologtostderr                  log to standard error as well as files
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/ksuda/.kube/http-cache")
+      --cache-dir string                 Default HTTP cache directory (default "/home/dev/.kube/http-cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS
@@ -36,6 +40,7 @@ Flags:
   -n, --namespace string                 If present, the namespace scope for this CLI request
   -p, --port int                         The port on which to run the proxy. Set to 0 to pick a random port. (default 8001)
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --scheme string                    The scheme for connections between the apiserver and the service. It must be "http" or "https" if specfied.
   -s, --server string                    The address and port of the Kubernetes API server
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
       --token string                     Bearer token for authentication to the API server


### PR DESCRIPTION
This option allows you to specify the scheme for connections between the
apiserver and the service. It must be "http" or "https" if specfied.

/close #9 