### PR TITLE
Run `lint` on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,15 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
-    - name: Ensure go.mod is already tidied
-      run: go mod tidy && git diff -s --exit-code go.sum
     - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - run: make vet fmt dist
+    - name: Ensure go.mod is already tidied
+      run: go mod tidy && git diff -s --exit-code go.sum
+    - run: make vet
+    - run: make fmt
+    - run: make lint
+    - run: make dist


### PR DESCRIPTION
I forgot to add a step that runs `golangci-lint` on CI.