### PR TITLE
Support for specify port name

### DIFF
--- a/pkg/cmd/open-svc.go
+++ b/pkg/cmd/open-svc.go
@@ -236,7 +236,7 @@ func (o *OpenServiceOptions) getServiceProxyPath(svc *v1.Service) (string, error
 
 	var port v1.ServicePort
 
-	if len(o.svcPort) == 0 {
+	if o.svcPort == "" {
 		port = svc.Spec.Ports[0]
 
 		if l > 1 {

--- a/pkg/cmd/open-svc.go
+++ b/pkg/cmd/open-svc.go
@@ -109,7 +109,7 @@ func NewCmdOpenService(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().IntVarP(&o.port, "port", "p", o.port, "The port on which to run the proxy. Set to 0 to pick a random port.")
-	cmd.Flags().StringVar(&o.portName, "port-name", o.portName, "The service port name. default is empty and uses the first port")
+	cmd.Flags().StringVar(&o.svcPort, "svc-port", o.svcPort, "The service port name. default is empty and uses the first port")
 	cmd.Flags().StringVar(&o.address, "address", o.address, "The IP address on which to serve on.")
 	cmd.Flags().DurationVar(&o.keepalive, "keepalive", o.keepalive, "keepalive specifies the keep-alive period for an active network connection. Set to 0 to disable keepalive.")
 	cmd.Flags().StringVar(&o.scheme, "scheme", o.scheme, `The scheme for connections between the apiserver and the service. It must be "http" or "https" if specfied.`)

--- a/pkg/cmd/open-svc.go
+++ b/pkg/cmd/open-svc.go
@@ -47,6 +47,9 @@ var (
 		# Open service/kubernetes-dashboard in namespace/kube-system
 		kubectl open-svc kubernetes-dashboard -n kube-system
 
+		# Open http-monitoring port name of service/istiod in namespace/istio-system
+		kubectl open-svc istiod -n istio-system --svc-port http-monitoring
+
 		# Use "https" scheme with --scheme option for connections between the apiserver
 		# and service/rook-ceph-mgr-dashboard in namespace/rook-ceph
 		kubectl open-svc rook-ceph-mgr-dashboard -n rook-ceph --scheme https
@@ -60,7 +63,7 @@ type OpenServiceOptions struct {
 
 	args      []string
 	port      int
-	portName  string
+	svcPort   string
 	address   string
 	keepalive time.Duration
 	scheme    string
@@ -233,7 +236,7 @@ func (o *OpenServiceOptions) getServiceProxyPath(svc *v1.Service) (string, error
 
 	var port v1.ServicePort
 
-	if len(o.portName) == 0 {
+	if len(o.svcPort) == 0 {
 		port = svc.Spec.Ports[0]
 
 		if l > 1 {
@@ -241,14 +244,14 @@ func (o *OpenServiceOptions) getServiceProxyPath(svc *v1.Service) (string, error
 		}
 	} else {
 		for _, p := range svc.Spec.Ports {
-			if p.Name == o.portName {
+			if p.Name == o.svcPort {
 				port = p
 				break
 			}
 		}
 
 		if len(port.Name) == 0 {
-			return "", fmt.Errorf("port %s not found for service/%s", o.portName, svc.GetName())
+			return "", fmt.Errorf("port %s not found in service/%s", o.svcPort, svc.GetName())
 		}
 	}
 

--- a/pkg/cmd/open-svc.go
+++ b/pkg/cmd/open-svc.go
@@ -250,7 +250,7 @@ func (o *OpenServiceOptions) getServiceProxyPath(svc *v1.Service) (string, error
 			}
 		}
 
-		if len(port.Name) == 0 {
+		if port.Name == "" {
 			return "", fmt.Errorf("port %s not found in service/%s", o.svcPort, svc.GetName())
 		}
 	}

--- a/pkg/cmd/open-svc.go
+++ b/pkg/cmd/open-svc.go
@@ -251,7 +251,7 @@ func (o *OpenServiceOptions) getServiceProxyPath(svc *v1.Service) (string, error
 		}
 
 		if port.Name == "" {
-			return "", fmt.Errorf("port %s not found in service/%s", o.svcPort, svc.GetName())
+			return "", fmt.Errorf("port %q not found in service/%s", o.svcPort, svc.GetName())
 		}
 	}
 

--- a/pkg/cmd/open-svc_test.go
+++ b/pkg/cmd/open-svc_test.go
@@ -211,10 +211,10 @@ func TestOpenServiceOptionsGetServiceProxyPath(t *testing.T) {
 			"Looks like service/nginx is a headless service",
 		},
 		{
-			"no ports by portName",
+			"no ports by service port name",
 			&OpenServiceOptions{
 				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
-				portName:  "noport",
+				svcPort:   "noport",
 			},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -230,13 +230,13 @@ func TestOpenServiceOptionsGetServiceProxyPath(t *testing.T) {
 				},
 			},
 			"",
-			"port noport not found for service/nginx",
+			"port noport not found in service/nginx",
 		},
 		{
-			"not specified scheme by portName",
+			"not specified scheme by service port name",
 			&OpenServiceOptions{
 				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
-				portName:  "metrics",
+				svcPort:   "metrics",
 			},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -260,10 +260,10 @@ func TestOpenServiceOptionsGetServiceProxyPath(t *testing.T) {
 			"",
 		},
 		{
-			"specified scheme by portName",
+			"specified scheme by service port name",
 			&OpenServiceOptions{
 				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
-				portName:  "https",
+				svcPort:   "https",
 			},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -283,7 +283,7 @@ func TestOpenServiceOptionsGetServiceProxyPath(t *testing.T) {
 					},
 				},
 			},
-			"/api/v1/namespaces/default/services/nginx:https:https/proxy",
+			"/api/v1/namespaces/default/services/https:nginx:https/proxy",
 			"",
 		},
 	}

--- a/pkg/cmd/open-svc_test.go
+++ b/pkg/cmd/open-svc_test.go
@@ -210,6 +210,82 @@ func TestOpenServiceOptionsGetServiceProxyPath(t *testing.T) {
 			"",
 			"Looks like service/nginx is a headless service",
 		},
+		{
+			"no ports by portName",
+			&OpenServiceOptions{
+				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+				portName:  "noport",
+			},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			"",
+			"port noport not found for service/nginx",
+		},
+		{
+			"not specified scheme by portName",
+			&OpenServiceOptions{
+				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+				portName:  "metrics",
+			},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name: "https",
+							Port: 443,
+						},
+						{
+							Name: "metrics",
+							Port: 10254,
+						},
+					},
+				},
+			},
+			"/api/v1/namespaces/default/services/nginx:metrics/proxy",
+			"",
+		},
+		{
+			"specified scheme by portName",
+			&OpenServiceOptions{
+				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+				portName:  "https",
+			},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name: "https",
+							Port: 443,
+						},
+						{
+							Name: "metrics",
+							Port: 10254,
+						},
+					},
+				},
+			},
+			"/api/v1/namespaces/default/services/nginx:https:https/proxy",
+			"",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/open-svc_test.go
+++ b/pkg/cmd/open-svc_test.go
@@ -230,7 +230,7 @@ func TestOpenServiceOptionsGetServiceProxyPath(t *testing.T) {
 				},
 			},
 			"",
-			"port noport not found in service/nginx",
+			"port \"noport\" not found in service/nginx",
 		},
 		{
 			"not specified scheme by service port name",


### PR DESCRIPTION
Fix: https://github.com/superbrothers/kubectl-open-svc-plugin/issues/88

This pull request support specify the port name.

```sh
./kubectl-open_svc istiod --svc-port http-monitoring
```

